### PR TITLE
New PSG

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sega-master-system/jt89"]
+	path = sega-master-system/jt89
+	url = git@github.com:jotego/jt89.git

--- a/sega-master-system/vhdl/sms_mist.qsf
+++ b/sega-master-system/vhdl/sms_mist.qsf
@@ -314,6 +314,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_COLOR 2147039 -section_id Top
 
 
+set_global_assignment -name QIP_FILE ../jt89/hdl/jt89.qip
 set_global_assignment -name VERILOG_FILE src/data_io.v
 set_global_assignment -name VERILOG_FILE src/osd.v
 set_global_assignment -name VERILOG_FILE src/user_io.v
@@ -333,9 +334,6 @@ set_global_assignment -name VHDL_FILE src/uart_tx.vhd
 set_global_assignment -name VHDL_FILE src/system.vhd
 set_global_assignment -name VHDL_FILE src/spi.vhd
 set_global_assignment -name VHDL_FILE src/sms_mist.vhd
-set_global_assignment -name VHDL_FILE src/psg_tone.vhd
-set_global_assignment -name VHDL_FILE src/psg_noise.vhd
-set_global_assignment -name VHDL_FILE src/psg.vhd
 set_global_assignment -name VHDL_FILE src/io.vhd
 set_global_assignment -name VHDL_FILE src/dummy_z80.vhd
 set_global_assignment -name VHDL_FILE src/dac.vhd

--- a/sega-master-system/vhdl/src/dac.vhd
+++ b/sega-master-system/vhdl/src/dac.vhd
@@ -6,20 +6,20 @@ use IEEE.NUMERIC_STD.ALL;
 entity dac is
 	Port (
 		clk	: in  STD_LOGIC;
-		input	: in  STD_LOGIC_VECTOR (5 downto 0);
+		input	: in  STD_LOGIC_VECTOR (10 downto 0);
 		output: out STD_LOGIC);
 end dac;
 
 architecture rtl of dac is
 
-	signal delta_adder: unsigned(7 downto 0);
-	signal sigma_adder: unsigned(7 downto 0);
-	signal sigma_latch: unsigned(7 downto 0) := "01000000";
-	signal delta_b		: unsigned(7 downto 0);
+	signal delta_adder: unsigned(12 downto 0);
+	signal sigma_adder: unsigned(12 downto 0);
+	signal sigma_latch: unsigned(12 downto 0) := "0000001000000";
+	signal delta_b		: unsigned(12 downto 0);
 	
 begin
 
-	delta_b <= sigma_latch(7)&sigma_latch(7)&"000000";
+	delta_b <= sigma_latch(12)&sigma_latch(12)&"00000000000";
 	delta_adder <= unsigned(input) + delta_b;
 	sigma_adder <= delta_adder + sigma_latch;
 	
@@ -27,7 +27,7 @@ begin
 	begin
 		if rising_edge(clk) then
 			sigma_latch <= sigma_adder;
-			output <= sigma_adder(7);
+			output <= sigma_adder(12);
 		end if;
 	end process;
 

--- a/sega-master-system/vhdl/src/system.vhd
+++ b/sega-master-system/vhdl/src/system.vhd
@@ -2,7 +2,8 @@ library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use IEEE.NUMERIC_STD.ALL;
 
-use work.all;
+--use work.all;
+use work.jt89.all;
 
 entity system is
 	port (
@@ -86,14 +87,6 @@ architecture Behavioral of system is
 		color: 			out std_logic_vector (5 downto 0));
 	end component;
 	
-	component psg is
-   port (
-		clk:				in  STD_LOGIC;
-		WR_n:				in  STD_LOGIC;
-		D_in:				in  STD_LOGIC_VECTOR (7 downto 0);
-		output:			out STD_LOGIC);
-	end component;
-	
 	component io is
    port (
 		clk:				in		STD_LOGIC;
@@ -116,7 +109,13 @@ architecture Behavioral of system is
 		J2_tr:			in 	STD_LOGIC;
 		RESET:			in 	STD_LOGIC);
 	end component;
-	
+
+	component dac is
+	port (clk	: in  STD_LOGIC;
+			input	: in  STD_LOGIC_VECTOR (10 downto 0);
+			output: out STD_LOGIC);
+	end component;
+
 	signal RESET_n:			std_logic;
 	signal RD_n:				std_logic;
 	signal WR_n:				std_logic;
@@ -125,27 +124,27 @@ architecture Behavioral of system is
 	signal A:					std_logic_vector(15 downto 0);
 	signal D_in:				std_logic_vector(7 downto 0);
 	signal D_out:				std_logic_vector(7 downto 0);
-	
+
 	signal vdp_RD_n:			std_logic;
 	signal vdp_WR_n:			std_logic;
 	signal vdp_D_out:			std_logic_vector(7 downto 0);
-	
+
 	signal psg_WR_n:			std_logic;
-	
+
 	signal ctl_WR_n:			std_logic;
-	
+
 	signal io_RD_n:			std_logic;
 	signal io_WR_n:			std_logic;
 	signal io_D_out:			std_logic_vector(7 downto 0);
-	
+
 	signal ram_WR_n:			std_logic;
 	signal ram_D_out:			std_logic_vector(7 downto 0);
-  signal cart_ram_D_out:std_logic_vector(7 downto 0);
-	
+	signal cart_ram_D_out:std_logic_vector(7 downto 0);
+
 	signal rom_WR_n:			std_logic;
-	
+
 	signal boot_rom_D_out:	std_logic_vector(7 downto 0);
-	
+
 	signal reset_counter:	unsigned(3 downto 0) := "1111";
 	signal bootloader:		std_logic := '0';
 	signal irom_D_out:		std_logic_vector(7 downto 0);
@@ -154,8 +153,10 @@ architecture Behavioral of system is
 	signal bank0:				std_logic_vector(7 downto 0) := "00000000";
 	signal bank1:				std_logic_vector(7 downto 0) := "00000001";
 	signal bank2:				std_logic_vector(7 downto 0) := "00000010";
-  
-  signal ram_e:       std_logic := '0';
+
+	signal ram_e:       std_logic := '0';
+	signal psg_sound : std_logic_vector(10 downto 0);	
+
 begin	
 	
 --	z80_inst: dummy_z80
@@ -196,14 +197,23 @@ begin
 		vblank		=> vblank,
 		hblank		=> hblank,
 		color			=> color);
-		
-	psg_inst: psg
-	port map (
-		clk			=> clk_cpu,
-		WR_n			=> psg_WR_n,
-		D_in			=> D_in,
-		output		=> audio);
 	
+	psg_inst : jt89
+	port map(
+		rst    	=> not RESET_n,
+		clk		=> clk_cpu,
+		clk_en	=> '1',
+		wr_n	=> psg_WR_n,
+		din  	=> D_in,
+		sound	=> psg_sound
+	);
+	
+	inst_dac: dac
+	port map (
+		clk		=> clk_cpu,
+		input   => psg_sound,
+		output	=> audio );
+
 	io_inst: io
    port map (
 		clk			=> clk_cpu,


### PR DESCRIPTION
Adds jt89 instead of old PSG:

-Correct volume table with good resolution
-Low pass filter to avoid fast edges
-Clock enable signals properly applied on negative edge so it can be used as direct enable
-Minor accuracy items according to available documentation

Verified on MiST with several games that make use of all 4 channels at the same time, like "Streets of Rage"